### PR TITLE
Implement vm_protect sys call

### DIFF
--- a/Sources/SimpleDebugger/SimpleDebugger.cpp
+++ b/Sources/SimpleDebugger/SimpleDebugger.cpp
@@ -17,6 +17,7 @@
 #import <mach-o/dyld_images.h>
 
 #include "mach_messages.h"
+#include "emg_vm_protect.h"
 
 #include <mach/exception.h>
 #include <mach/arm/thread_state.h>
@@ -67,7 +68,7 @@ void SimpleDebugger::setExceptionCallback(ExceptionCallback callback) {
 #define ARM64_BREAK_INSTRUCTION 0xD4200000
 
 void protectPage(vm_address_t address, vm_size_t size, vm_prot_t newProtection) {
-  kern_return_t result = vm_protect(mach_task_self(), address, size, 0, newProtection);
+  kern_return_t result = emg_vm_protect(mach_task_self(), address, size, 0, newProtection);
 
   if (result != 0) {
     printf("error calling vm_protect: %s (response value: %d)\n", mach_error_string(result), result);

--- a/Sources/SimpleDebugger/emg_vm_protect.c
+++ b/Sources/SimpleDebugger/emg_vm_protect.c
@@ -1,0 +1,31 @@
+//
+//  emg_vm_protect.c
+//  SimpleDebugger
+//
+//  Created by Noah Martin on 12/10/24.
+//
+
+#import "emg_vm_protect.h"
+#import <mach/mach.h>
+
+extern kern_return_t _kern_rpc_emg_vm_prot_trap(
+  mach_port_name_t target,
+  mach_vm_address_t address,
+  mach_vm_size_t size,
+  boolean_t set_maximum,
+  vm_prot_t new_protection
+  );
+
+asm(
+    ".globl __kern_rpc_emg_vm_prot_trap\n"
+    ".text\n"
+    ".align 2\n"
+    "__kern_rpc_emg_vm_prot_trap:\n"
+    "    mov x16, #-14\n"
+    "    svc 0x80\n"
+    "    ret\n"
+);
+
+kern_return_t emg_vm_protect(mach_port_t target, mach_vm_address_t address, mach_vm_size_t size, boolean_t set_maximum, vm_prot_t new_protection) {
+  return _kern_rpc_emg_vm_prot_trap(target, address, size, set_maximum, new_protection);
+}

--- a/Sources/SimpleDebugger/emg_vm_protect.h
+++ b/Sources/SimpleDebugger/emg_vm_protect.h
@@ -1,0 +1,23 @@
+//
+//  emg_vm_protect.h
+//  SimpleDebugger
+//
+//  Created by Noah Martin on 12/10/24.
+//
+
+#import <mach/mach.h>
+
+#ifndef EMG_VM_PROTECT
+#define EMG_VM_PROTECT
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+kern_return_t emg_vm_protect(mach_port_t target, mach_vm_address_t address, mach_vm_size_t size, boolean_t set_maximum, vm_prot_t new_protection);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Replace calls to vm_protect with a direct sys call. This way we can set breakpoints on functions defined on the same page as vm_protect, or on vm_protect itself.